### PR TITLE
removed version from docker-compose per new standard

### DIFF
--- a/nginx/nginx/docker-compose.yaml
+++ b/nginx/nginx/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+name: nginx
 services:
     nginx:
         image: nginx


### PR DESCRIPTION
docker compose standard doesn't use version any longer, but does use name